### PR TITLE
Fix resume functionality and z-positioning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [**.py]
-indent_style = tab
+indent_style = space
 
 [**.js]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [**.py]
-indent_style = space
+indent_style = tab
 
 [**.js]
 indent_style = space

--- a/octoprint_RewriteM600/__init__.py
+++ b/octoprint_RewriteM600/__init__.py
@@ -15,45 +15,48 @@ import octoprint.plugin
 
 class Rewritem600Plugin(octoprint.plugin.AssetPlugin, octoprint.plugin.TemplatePlugin, octoprint.plugin.SettingsPlugin):
     pattern = re.compile('X:([0-9.]+) Y:([0-9.]+) Z:([0-9.]+) E:([0-9.]+) Count X:([0-9]+) Y:([0-9]+) Z:([0-9]+)')
-    cached_position = {"x": 0, "y": 0, "z": 0}
+    cached_position = {"x": "NOT SET", "y": "NOT SET", "z": "NOT SET", "e": "NOT SET"}
+    listening = False
 
     def rewrite_m600(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
         if gcode and gcode == "M600":
-            self._plugin_manager.send_plugin_message(self._identifier, dict(type = "popup",
-                                                                            msg = "Please change the filament and resume the print"))
+            self._plugin_manager.send_plugin_message(self._identifier,
+                                                     dict(type = "popup",
+                                                          msg = "Please change the filament and resume the print"))
             comm_instance.setPause(True)
+            self.listening = True  # We need to listen to the first result of M114, so we can cache position
             cmd = ["M114", ("M117 Filament Change",), "G91", "M83",
                    "G1 Z+" + str(self._settings.get(["zDistance"])) + " E-0.8 F4500", "M82", "G90", "G1 X0 Y0"]
+
         return cmd
 
     def detect_position(self, comm_instance, line, *args, **kwargs):
         match = self.pattern.match(line)
-        if match is not None:
+        if match is not None and self.listening:
             self.cached_position["x"] = match.group(1)
             self.cached_position["y"] = match.group(2)
             self.cached_position["z"] = match.group(3)
             self.cached_position["e"] = match.group(3)
-            return line
+            self.listening = False  # Reset so we don't listen to the update called on print pause
         return line
 
     def after_resume(self, comm_instance, phase, cmd, parameters, tags = None, *args, **kwargs):
         if cmd and cmd == "resume":
-            if (comm_instance.pause_position.x):
-                cmd = ["M83", "G1 E-0.8 F4500", "G1 E0.8 F4500", "G1 E0.8 F4500", "M82", "G90",
-                       "G92 E" + str(comm_instance.pause_position.e), "M83",
-                       "G1 X" + str(comm_instance.pause_position.x) +
-                       " Y" + str(comm_instance.pause_position.y) +
-                       " Z" + str(comm_instance.pause_position.z) + " F4500"]
-                if (comm_instance.pause_position.f):
-                    cmd.append("G1 F" + str(comm_instance.pause_position.f))
-            else:  # use our cached position
-                self.cached_position["x"]
-                cmd = ["M83", "G1 E-0.8 F4500", "G1 E0.8 F4500", "G1 E0.8 F4500", "M82", "G90",
-                       "G92 E" + str(self.cached_position["e"]), "M83",
-                       "G1 X" + str(self.cached_position["x"]) +
-                       " Y" + str(self.cached_position["y"]) +
-                       " Z" + str(self.cached_position["z"]) + " F4500"]
-                if (comm_instance.pause_position.f):
+            if self.cached_position["x"] is not "NOT SET":  # use our cached position
+                cmd = [
+                    # We'll assume that the user manually inserted and purged the new filament, so no new extrusion
+                    # is required here
+                    # "M83", "G1 E-0.8 F4500", "G1 E0.8 F4500", "G1 E0.8 F4500",
+                    "M82", "G90",  # Reset to absolute positioning
+                    # I don't think we really need the extrusion to be set here?
+                    # The gcode that follows will set it itself.
+                    # "G92 E" + str(self.cached_position["e"]),
+                    "M83",  # Reset our extruder mode to absolute
+                    # Reset our position to pre-M600 positions
+                    "G1 X" + str(self.cached_position["x"]) +
+                    " Y" + str(self.cached_position["y"]) +
+                    " Z" + str(self.cached_position["z"]) + " F4500"]
+                if comm_instance.pause_position.f:
                     cmd.append("G1 F" + str(comm_instance.pause_position.f))
             comm_instance.commands(cmd)
             comm_instance.setPause(False)

--- a/octoprint_RewriteM600/__init__.py
+++ b/octoprint_RewriteM600/__init__.py
@@ -28,25 +28,6 @@ class Rewritem600Plugin(octoprint.plugin.AssetPlugin, octoprint.plugin.TemplateP
 			cmd = ["M114", ("M117 Filament Change",), "G91", "M83", "G1 E-2 F2700", "G1 Z0.05", "G1 X5 Y5", "G1 Z+" + str(self._settings.get(["zDistance"])) + " F4500", "M82", "G90", "G1 X0 Y0 F4500"]
 			self._logger.info(self.cached_position)
 			self.waiting = True
-		elif gcode and gcode == "M601":
-			self._plugin_manager.send_plugin_message(self._identifier, dict(type = "popup", msg = "Resuming to location at X:" +
-								self.cached_position["x"] + " Y:" + self.cached_position["y"] +
-								" Z:" + self.cached_position["z"]))
-			if self.cached_position["x"] != "NOT SET":
-				cmd = [
-					# We'll assume that the user manually inserted and purged the new filament, so no new extrusion
-					# is required here
-					# "M83", "G1 E-0.8 F4500", "G1 E0.8 F4500", "G1 E0.8 F4500",
-					"M82", "G90",  # Reset to absolute positioning
-					"G92 E" + str(self.cached_position["e"]),
-					# Reset our position to pre-M600 positions
-					"G1 Z" + str(self.cached_position["z"]),
-					"G1 X" + str(self.cached_position["x"]) +
-					" Y" + str(self.cached_position["y"]) + " F4500"]
-				if comm_instance.pause_position.f:
-					cmd.append("G1 F" + str(comm_instance.pause_position.f))
-				self.cached_position = {"x": "NOT SET", "y": "NOT SET", "z": "NOT SET", "e": "NOT SET"}
-				comm_instance.setPause(False)
 
 		return cmd
 

--- a/octoprint_RewriteM600/__init__.py
+++ b/octoprint_RewriteM600/__init__.py
@@ -25,7 +25,7 @@ class Rewritem600Plugin(octoprint.plugin.AssetPlugin, octoprint.plugin.TemplateP
 			                                              msg = "Please change the filament and resume the print"))
 			comm_instance.setPause(True)
 			self.listening = True  # We need to listen to the first result of M114, so we can cache position
-			cmd = ["M114", ("M117 Filament Change",), "G91", "M83", "G1 Z+" + str(self._settings.get(["zDistance"])) + " E-0.8 F4500", "M82", "G90", "G1 X0 Y0 F4500"]
+			cmd = ["M114", ("M117 Filament Change",), "G91", "M83", "G1 E-2 F2700", "G1 Z0.05", "G1 X5 Y5", "G1 Z+" + str(self._settings.get(["zDistance"])) + " F4500", "M82", "G90", "G1 X0 Y0 F4500"]
 			self._logger.info(self.cached_position)
 			self.waiting = True
 		elif gcode and gcode == "M601":
@@ -38,10 +38,7 @@ class Rewritem600Plugin(octoprint.plugin.AssetPlugin, octoprint.plugin.TemplateP
 					# is required here
 					# "M83", "G1 E-0.8 F4500", "G1 E0.8 F4500", "G1 E0.8 F4500",
 					"M82", "G90",  # Reset to absolute positioning
-					# I don't think we really need the extrusion to be set here?
-					# The gcode that follows will set it itself.
-					# "G92 E" + str(self.cached_position["e"]),
-					"M83",  # Reset our extruder mode to absolute
+					"G92 E" + str(self.cached_position["e"]),
 					# Reset our position to pre-M600 positions
 					"G1 Z" + str(self.cached_position["z"]),
 					"G1 X" + str(self.cached_position["x"]) +
@@ -80,12 +77,9 @@ class Rewritem600Plugin(octoprint.plugin.AssetPlugin, octoprint.plugin.TemplateP
 					# We'll assume that the user manually inserted and purged the new filament, so no new extrusion
 					# is required here
 					# "M83", "G1 E-0.8 F4500", "G1 E0.8 F4500", "G1 E0.8 F4500",
-					"M83", "G1 Z-" + str(self._settings.get(["zDistance"])) + " F4500",
+					# "M83", "G1 Z-" + str(self._settings.get(["zDistance"])) + " F4500",
 					"M82", "G90",  # Reset to absolute positioning
-					# I don't think we really need the extrusion to be set here?
-					# The gcode that follows will set it itself.
-					# "G92 E" + str(self.cached_position["e"]),
-					"M83",  # Reset our extruder mode to absolute
+					"G92 E" + str(self.cached_position["e"]),
 					# Reset our position to pre-M600 position
 					"G1 Z" + str(self.cached_position["z"]),
 					"G1 X" + str(self.cached_position["x"]) +
@@ -93,9 +87,7 @@ class Rewritem600Plugin(octoprint.plugin.AssetPlugin, octoprint.plugin.TemplateP
 				if comm_instance.pause_position.f:
 					cmd.append("G1 F" + str(comm_instance.pause_position.f))
 				self.cached_position = {"x": "NOT SET", "y": "NOT SET", "z": "NOT SET", "e": "NOT SET"}
-			comm_instance.commands(cmd)
-			comm_instance.setPause(False)
-		return
+			return cmd, None
 
 	def get_settings_defaults(self):
 		return dict(zDistance = 80)

--- a/octoprint_RewriteM600/__init__.py
+++ b/octoprint_RewriteM600/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import
+import re
 
 ### (Don't forget to remove me)
 # This is a basic skeleton for your plugin's __init__.py. You probably want to adjust the class name of your plugin
@@ -11,64 +12,94 @@ from __future__ import absolute_import
 
 import octoprint.plugin
 
+
 class Rewritem600Plugin(octoprint.plugin.AssetPlugin, octoprint.plugin.TemplatePlugin, octoprint.plugin.SettingsPlugin):
-	def rewrite_m600(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
-		if gcode and gcode == "M600":
-			self._plugin_manager.send_plugin_message(self._identifier, dict(type="popup", msg="Please change the filament and resume the print"))
-			comm_instance.setPause(True)
-			cmd = [("M117 Filament Change",),"G91","M83", "G1 Z+"+str(self._settings.get(["zDistance"]))+" E-0.8 F4500", "M82", "G90", "G1 X0 Y0"]
-		return cmd
+    pattern = re.compile('X:([0-9.]+) Y:([0-9.]+) Z:([0-9.]+) E:([0-9.]+) Count X:([0-9]+) Y:([0-9]+) Z:([0-9]+)')
+    cached_position = {"x": 0, "y": 0, "z": 0}
 
-	def after_resume(self, comm_instance, phase, cmd, parameters, tags=None, *args, **kwargs):
-		if cmd and cmd == "resume":
-			if(comm_instance.pause_position.x):
-				cmd = []
-				cmd =["M83","G1 E-0.8 F4500", "G1 E0.8 F4500", "G1 E0.8 F4500", "M82", "G90", "G92 E"+str(comm_instance.pause_position.e), "M83", "G1 X"+str(comm_instance.pause_position.x)+" Y"+str(comm_instance.pause_position.y)+" Z"+str(comm_instance.pause_position.z)+" F4500"]
-				if(comm_instance.pause_position.f):
-					cmd.append("G1 F" + str(comm_instance.pause_position.f))
-				comm_instance.commands(cmd)
-			comm_instance.setPause(False)
-		return
-	def get_settings_defaults(self):
-		return dict(zDistance=80)
+    def rewrite_m600(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
+        if gcode and gcode == "M600":
+            self._plugin_manager.send_plugin_message(self._identifier, dict(type = "popup",
+                                                                            msg = "Please change the filament and resume the print"))
+            comm_instance.setPause(True)
+            cmd = ["M114", ("M117 Filament Change",), "G91", "M83",
+                   "G1 Z+" + str(self._settings.get(["zDistance"])) + " E-0.8 F4500", "M82", "G90", "G1 X0 Y0"]
+        return cmd
 
-	def get_template_configs(self):
-		return [
-			dict(type="navbar", custom_bindings=False),
-			dict(type="settings", custom_bindings=False)
-		]
-	##~~ AssetPlugin mixin
+    def detect_position(self, comm_instance, line, *args, **kwargs):
+        match = self.pattern.match(line)
+        if match is not None:
+            self.cached_position["x"] = match.group(1)
+            self.cached_position["y"] = match.group(2)
+            self.cached_position["z"] = match.group(3)
+            self.cached_position["e"] = match.group(3)
+            return line
+        return line
 
-	def get_assets(self):
-		# Define your plugin's asset files to automatically include in the
-		# core UI here.
-		return dict(
-			js=["js/RewriteM600.js"],
-			css=["css/RewriteM600.css"],
-			less=["less/RewriteM600.less"]
-		)
+    def after_resume(self, comm_instance, phase, cmd, parameters, tags = None, *args, **kwargs):
+        if cmd and cmd == "resume":
+            if (comm_instance.pause_position.x):
+                cmd = ["M83", "G1 E-0.8 F4500", "G1 E0.8 F4500", "G1 E0.8 F4500", "M82", "G90",
+                       "G92 E" + str(comm_instance.pause_position.e), "M83",
+                       "G1 X" + str(comm_instance.pause_position.x) +
+                       " Y" + str(comm_instance.pause_position.y) +
+                       " Z" + str(comm_instance.pause_position.z) + " F4500"]
+                if (comm_instance.pause_position.f):
+                    cmd.append("G1 F" + str(comm_instance.pause_position.f))
+            else:  # use our cached position
+                self.cached_position["x"]
+                cmd = ["M83", "G1 E-0.8 F4500", "G1 E0.8 F4500", "G1 E0.8 F4500", "M82", "G90",
+                       "G92 E" + str(self.cached_position["e"]), "M83",
+                       "G1 X" + str(self.cached_position["x"]) +
+                       " Y" + str(self.cached_position["y"]) +
+                       " Z" + str(self.cached_position["z"]) + " F4500"]
+                if (comm_instance.pause_position.f):
+                    cmd.append("G1 F" + str(comm_instance.pause_position.f))
+            comm_instance.commands(cmd)
+            comm_instance.setPause(False)
+        return
 
-	##~~ Softwareupdate hook
+    def get_settings_defaults(self):
+        return dict(zDistance = 80)
 
-	def get_update_information(self):
-		# Define the configuration for your plugin to use with the Software Update
-		# Plugin here. See https://docs.octoprint.org/en/master/bundledplugins/softwareupdate.html
-		# for details.
-		return dict(
-			RewriteM600=dict(
-				displayName="Rewritem600 Plugin",
-				displayVersion=self._plugin_version,
+    def get_template_configs(self):
+        return [
+            dict(type = "navbar", custom_bindings = False),
+            dict(type = "settings", custom_bindings = False)
+        ]
 
-				# version check: github repository
-				type="github_release",
-				user="wgcv",
-				repo="RewriteM600",
-				current=self._plugin_version,
+    ##~~ AssetPlugin mixin
 
-				# update method: pip
-				pip="https://github.com/wgcv/RewriteM600/archive/{target_version}.zip"
-			)
-		)
+    def get_assets(self):
+        # Define your plugin's asset files to automatically include in the
+        # core UI here.
+        return dict(
+            js = ["js/RewriteM600.js"],
+            css = ["css/RewriteM600.css"],
+            less = ["less/RewriteM600.less"]
+        )
+
+    ##~~ Softwareupdate hook
+
+    def get_update_information(self):
+        # Define the configuration for your plugin to use with the Software Update
+        # Plugin here. See https://docs.octoprint.org/en/master/bundledplugins/softwareupdate.html
+        # for details.
+        return dict(
+            RewriteM600 = dict(
+                displayName = "Rewritem600 Plugin",
+                displayVersion = self._plugin_version,
+
+                # version check: github repository
+                type = "github_release",
+                user = "wgcv",
+                repo = "RewriteM600",
+                current = self._plugin_version,
+
+                # update method: pip
+                pip = "https://github.com/wgcv/RewriteM600/archive/{target_version}.zip"
+            )
+        )
 
 
 # If you want your plugin to be registered within OctoPrint under a different name than what you defined in setup.py
@@ -79,18 +110,19 @@ __plugin_name__ = "Filament Change - M600 Rewriter"
 # Starting with OctoPrint 1.4.0 OctoPrint will also support to run under Python 3 in addition to the deprecated
 # Python 2. New plugins should make sure to run under both versions for now. Uncomment one of the following
 # compatibility flags according to what Python versions your plugin supports!
-#__plugin_pythoncompat__ = ">=2.7,<3" # only python 2
-#__plugin_pythoncompat__ = ">=3,<4" # only python 3
-__plugin_pythoncompat__ = ">=2.7,<4" # python 2 and 3
+# __plugin_pythoncompat__ = ">=2.7,<3" # only python 2
+# __plugin_pythoncompat__ = ">=3,<4" # only python 3
+__plugin_pythoncompat__ = ">=2.7,<4"  # python 2 and 3
+
 
 def __plugin_load__():
-	global __plugin_implementation__
-	__plugin_implementation__ = Rewritem600Plugin()
+    global __plugin_implementation__
+    __plugin_implementation__ = Rewritem600Plugin()
 
-	global __plugin_hooks__
-	__plugin_hooks__ = {
-		"octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
-		"octoprint.comm.protocol.gcode.queuing": __plugin_implementation__.rewrite_m600,
-		"octoprint.comm.protocol.atcommand.queuing": __plugin_implementation__.after_resume,
-	}
-
+    global __plugin_hooks__
+    __plugin_hooks__ = {
+        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
+        "octoprint.comm.protocol.gcode.queuing": __plugin_implementation__.rewrite_m600,
+        "octoprint.comm.protocol.atcommand.queuing": __plugin_implementation__.after_resume,
+        "octoprint.comm.protocol.gcode.received": __plugin_implementation__.detect_position,
+    }

--- a/octoprint_RewriteM600/static/js/RewriteM600.js
+++ b/octoprint_RewriteM600/static/js/RewriteM600.js
@@ -23,7 +23,7 @@ $(function() {
 						title: 'M600',
 						text: data.msg,
 						type: "info",
-						hide: false
+						hide: true
 						});
 				}
             }

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ plugin_author = "Gustavo Cevallos"
 plugin_author_email = "gstavocevallos@gmail.com"
 
 # The plugin's homepage URL. Can be overwritten within OctoPrint's internal data via __plugin_url__ in the plugin module
-plugin_url = "https://github.com/Travja/RewriteM600"
+plugin_url = "https://github.com/wgcv/RewriteM600"
 
 # The plugin's license. Can be overwritten within OctoPrint's internal data via __plugin_license__ in the plugin module
 plugin_license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,11 @@
 plugin_identifier = "RewriteM600"
 
 # The plugin's python package, should be "octoprint_<plugin identifier>", has to be unique
-plugin_package = "octoprint_RewriteM600_Travja"
+plugin_package = "octoprint_RewriteM600"
 
 # The plugin's human readable name. Can be overwritten within OctoPrint's internal data via __plugin_name__ in the
 # plugin module
-plugin_name = "RewriteM600_Travja"
+plugin_name = "RewriteM600"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 plugin_version = "1.0.5"
@@ -21,7 +21,7 @@ plugin_version = "1.0.5"
 plugin_description = """Implement M600 for pinters that can't support M600 by default (TFT with out marlin mode support, like Artilelry X1 and Genius)"""
 
 # The plugin's author. Can be overwritten within OctoPrint's internal data via __plugin_author__ in the plugin module
-plugin_author = "Gustavo Cevallos/Travja"
+plugin_author = "Gustavo Cevallos"
 
 # The plugin's author's mail address.
 plugin_author_email = "gstavocevallos@gmail.com"
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/Travja/RewriteM600"
 plugin_license = "MIT"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ['re']
+plugin_requires = []
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,11 @@
 plugin_identifier = "RewriteM600"
 
 # The plugin's python package, should be "octoprint_<plugin identifier>", has to be unique
-plugin_package = "octoprint_RewriteM600"
+plugin_package = "octoprint_RewriteM600_Travja"
 
 # The plugin's human readable name. Can be overwritten within OctoPrint's internal data via __plugin_name__ in the
 # plugin module
-plugin_name = "RewriteM600"
+plugin_name = "RewriteM600_Travja"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 plugin_version = "1.0.5"
@@ -21,19 +21,19 @@ plugin_version = "1.0.5"
 plugin_description = """Implement M600 for pinters that can't support M600 by default (TFT with out marlin mode support, like Artilelry X1 and Genius)"""
 
 # The plugin's author. Can be overwritten within OctoPrint's internal data via __plugin_author__ in the plugin module
-plugin_author = "Gustavo Cevallos"
+plugin_author = "Gustavo Cevallos/Travja"
 
 # The plugin's author's mail address.
 plugin_author_email = "gstavocevallos@gmail.com"
 
 # The plugin's homepage URL. Can be overwritten within OctoPrint's internal data via __plugin_url__ in the plugin module
-plugin_url = "https://github.com/wgcv/RewriteM600"
+plugin_url = "https://github.com/Travja/RewriteM600"
 
 # The plugin's license. Can be overwritten within OctoPrint's internal data via __plugin_license__ in the plugin module
 plugin_license = "MIT"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = []
+plugin_requires = ['re']
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point
@@ -66,31 +66,33 @@ additional_setup_parameters = {}
 from setuptools import setup
 
 try:
-	import octoprint_setuptools
+    import octoprint_setuptools
 except:
-	print("Could not import OctoPrint's setuptools, are you sure you are running that under "
-	      "the same python installation that OctoPrint is installed under?")
-	import sys
-	sys.exit(-1)
+    print("Could not import OctoPrint's setuptools, are you sure you are running that under "
+          "the same python installation that OctoPrint is installed under?")
+    import sys
+
+    sys.exit(-1)
 
 setup_parameters = octoprint_setuptools.create_plugin_setup_parameters(
-	identifier=plugin_identifier,
-	package=plugin_package,
-	name=plugin_name,
-	version=plugin_version,
-	description=plugin_description,
-	author=plugin_author,
-	mail=plugin_author_email,
-	url=plugin_url,
-	license=plugin_license,
-	requires=plugin_requires,
-	additional_packages=plugin_additional_packages,
-	ignored_packages=plugin_ignored_packages,
-	additional_data=plugin_additional_data
+    identifier = plugin_identifier,
+    package = plugin_package,
+    name = plugin_name,
+    version = plugin_version,
+    description = plugin_description,
+    author = plugin_author,
+    mail = plugin_author_email,
+    url = plugin_url,
+    license = plugin_license,
+    requires = plugin_requires,
+    additional_packages = plugin_additional_packages,
+    ignored_packages = plugin_ignored_packages,
+    additional_data = plugin_additional_data
 )
 
 if len(additional_setup_parameters):
-	from octoprint.util import dict_merge
-	setup_parameters = dict_merge(setup_parameters, additional_setup_parameters)
+    from octoprint.util import dict_merge
+
+    setup_parameters = dict_merge(setup_parameters, additional_setup_parameters)
 
 setup(**setup_parameters)


### PR DESCRIPTION
I've sort of reworked how the plugin handles returning back to the correct position by caching it manually by interpreting the result of a M114 call. Additionally, I've changed a little bit of how it moves to prep for the filament swap. Hopefully the code all makes sense. Basically I'm mimicking the behavior of Cura and how it slices the last little bit of the GCode to scrape the nozzle a little to prevent a spike of filament. Anyway, the code should all make sense for anyone wanting to experiment and use this.